### PR TITLE
Remove host from manifest.js

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -20,7 +20,6 @@ var manifest = {
         }
     },
     connections: [{
-        host: '127.0.0.1',
         port: Config.get('/port/web'),
         labels: ['web']
     }],


### PR DESCRIPTION
Removing the host parameter and relying on the hapi default I think is a better, especially for newbies. In my case I wasn't able to access the server via my local ip on another system. 
Also have this omitted on my company's product setup.