### PR TITLE
Fix failing tests and CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
   - "0.12"
 services:
   - mongodb
+env:
+  - NODE_ENV=test
 before_script:
   - gulp react
   - npm run setup

--- a/test/client/pages/account/index.js
+++ b/test/client/pages/account/index.js
@@ -1,12 +1,11 @@
 var React = require('react/addons');
-var testLocation = require('react-router/lib/locations/TestLocation');
+var RouterTestLocation = require('react-router/lib/locations/TestLocation');
 var Lab = require('lab');
 var Code = require('code');
 var Proxyquire = require('proxyquire');
 
 
-var TestLocation = new testLocation();
-
+var TestLocation = new RouterTestLocation();
 var lab = exports.lab = Lab.script();
 var stub = {
     RedirectActions: {

--- a/test/client/pages/account/index.js
+++ b/test/client/pages/account/index.js
@@ -1,9 +1,11 @@
 var React = require('react/addons');
-var TestLocation = require('react-router/modules/locations/TestLocation');
+var testLocation = require('react-router/lib/locations/TestLocation');
 var Lab = require('lab');
 var Code = require('code');
 var Proxyquire = require('proxyquire');
 
+
+var TestLocation = new testLocation();
 
 var lab = exports.lab = Lab.script();
 var stub = {

--- a/test/client/pages/admin/index.js
+++ b/test/client/pages/admin/index.js
@@ -1,12 +1,11 @@
 var React = require('react/addons');
-var testLocation = require('react-router/lib/locations/TestLocation');
+var RouterTestLocation = require('react-router/lib/locations/TestLocation');
 var Lab = require('lab');
 var Code = require('code');
 var Proxyquire = require('proxyquire');
 
 
-var TestLocation = new testLocation();
-
+var TestLocation = new RouterTestLocation();
 var lab = exports.lab = Lab.script();
 var stub = {
     RedirectActions: {

--- a/test/client/pages/admin/index.js
+++ b/test/client/pages/admin/index.js
@@ -1,9 +1,11 @@
 var React = require('react/addons');
-var TestLocation = require('react-router/modules/locations/TestLocation');
+var testLocation = require('react-router/lib/locations/TestLocation');
 var Lab = require('lab');
 var Code = require('code');
 var Proxyquire = require('proxyquire');
 
+
+var TestLocation = new testLocation();
 
 var lab = exports.lab = Lab.script();
 var stub = {

--- a/test/client/pages/login/Actions.js
+++ b/test/client/pages/login/Actions.js
@@ -100,9 +100,7 @@ lab.experiment('Login Actions', function () {
             Code.expect(type).to.be.an.instanceOf(FluxConstant);
 
             if (type === ActionTypes.LOGIN_RESPONSE) {
-                var hostname = 'about:';
-
-                Code.expect(global.window.location.href).to.equal(hostname + returnUrl);
+                Code.expect(global.window.location.href).to.endWith(returnUrl);
                 Code.expect(data.success).to.equal(true);
                 done();
             }
@@ -140,9 +138,7 @@ lab.experiment('Login Actions', function () {
             Code.expect(type).to.be.an.instanceOf(FluxConstant);
 
             if (type === ActionTypes.LOGIN_RESPONSE) {
-                var hostname = 'about:';
-
-                Code.expect(global.window.location.href).to.equal(hostname + '/admin');
+                Code.expect(global.window.location.href).to.endWith('/admin');
                 Code.expect(data.success).to.equal(true);
                 done();
             }
@@ -180,9 +176,7 @@ lab.experiment('Login Actions', function () {
             Code.expect(type).to.be.an.instanceOf(FluxConstant);
 
             if (type === ActionTypes.LOGIN_RESPONSE) {
-                var hostname = 'about:';
-
-                Code.expect(global.window.location.href).to.equal(hostname + '/account');
+                Code.expect(global.window.location.href).to.endWith('/account');
                 Code.expect(data.success).to.equal(true);
                 done();
             }

--- a/test/client/pages/login/index.js
+++ b/test/client/pages/login/index.js
@@ -1,9 +1,11 @@
 var React = require('react/addons');
-var TestLocation = require('react-router/modules/locations/TestLocation');
+var testLocation = require('react-router/lib/locations/TestLocation');
 var Lab = require('lab');
 var Code = require('code');
 var Proxyquire = require('proxyquire');
 
+
+var TestLocation = new testLocation();
 
 var lab = exports.lab = Lab.script();
 var stub = {

--- a/test/client/pages/login/index.js
+++ b/test/client/pages/login/index.js
@@ -1,12 +1,11 @@
 var React = require('react/addons');
-var testLocation = require('react-router/lib/locations/TestLocation');
+var RouterTestLocation = require('react-router/lib/locations/TestLocation');
 var Lab = require('lab');
 var Code = require('code');
 var Proxyquire = require('proxyquire');
 
 
-var TestLocation = new testLocation();
-
+var TestLocation = new RouterTestLocation();
 var lab = exports.lab = Lab.script();
 var stub = {
     ReactRouter: {


### PR DESCRIPTION
**[Travis build is now passing](https://travis-ci.org/justingreenberg/aqua)**: The CI builds ([as of build 15](https://travis-ci.org/jedireza/aqua/builds/52175213)) have been timing out during the `npm run setup` process, corrected in commit https://github.com/justingreenberg/aqua/commit/03903374c97ae469d6786a5a061d63983bf36fe3 by setting `NODE_ENV=test` in travis.yml config to bypass user input.

*6 tests were also failing on my system.* The first three failures are related to the `react-router` npm package:*

```javascript
Failed tests:
  85) Account App it renders normally:
      Cannot call a class as a function
  491) Admin App it renders normally:
      Cannot call a class as a function
  705) Login App it renders normally:
      Cannot call a class as a function
```

Commit https://github.com/justingreenberg/aqua/commit/abca4be6144acd3af12a0286960712026128f867 corrects the tests above by pointing `react-router/modules` folder to `react-router/lib` to conform with the [current npm react-router package](https://github.com/rackt/react-router/tree/master/build/npm). Since the code has been transpiled to ES5, we also have to instantiate `TestLocation`. **The above test are now passing.** The other three failing tests:

```javascript
Failed tests:
  666) Login Actions it handles login successfully (redirect to returnUrl):
      Expected 'file:///deep/link' to equal specified value  // <---- js-dom issue?
  667) Login Actions it handles login successfully (redirect to admin):
      Expected 'file:///admin' to equal specified value
  668) Login Actions it handles login successfully (redirect to account):
      Expected 'file:///account' to equal specified value

```

These failures are due to the way js-dom is prepending `location.href` with `file://` (I'm using OSX Mavericks—could just be my system or maybe varies by OS? Who knows). Anyways, in commit  https://github.com/justingreenberg/aqua/commit/21c1806b14cf45b60835c8c93677a4c4288ce4f8 I made the tests a little more flexible by removing hostname and asserting `.endsWith(\* testLocation *\)`, which I think still gets the job done!

My system setup for reference:

```javascript
{ aqua: '1.0.1',
  npm: '2.5.1',
  http_parser: '2.3',
  modules: '14',
  node: '0.12.0',
  openssl: '1.0.1l',
  uv: '1.0.2',
  v8: '3.28.73',
  zlib: '1.2.8' }
```

*Also—sorry for committing on master, I forgot to create fix branch!*

Great work! :+1: 