### PR TITLE
using baseUrl config instead of `request.server.info.uri`

### DIFF
--- a/config.example
+++ b/config.example
@@ -17,6 +17,12 @@ var config = {
             $default: 8000
         }
     },
+    baseUrl: {
+        $filter: 'env',
+        $meta: 'values should not end in "/"',
+        production: 'https://getaqua.herokuapp.com',
+        $default: 'http://127.0.0.1:8000'
+    },
     authAttempts: {
         forIp: 50,
         forIpAndUser: 7

--- a/manifest.js
+++ b/manifest.js
@@ -20,7 +20,6 @@ var manifest = {
         }
     },
     connections: [{
-        host: '127.0.0.1',
         port: Config.get('/port/web'),
         labels: ['web']
     }],

--- a/server/api/login.js
+++ b/server/api/login.js
@@ -197,7 +197,7 @@ exports.register = function (server, options, next) {
                     };
                     var template = 'forgot-password';
                     var context = {
-                        baseHref: request.server.info.uri + '/login/reset',
+                        baseHref: Config.get('/baseUrl') + '/login/reset',
                         email: request.payload.email,
                         key: results.keyHash.key
                     };


### PR DESCRIPTION
We can't really depend on `request.server.info.uri` to help create a base URL for links.

This is not the most ideal solution. I wish there was a clean way of using the port configuration dynamically. But the live demo's forgot password functionality doesn't work in the current state.

Related: #4 and #23