### PR TITLE
Unwatch node_modules

### DIFF
--- a/gulp/nodemon.js
+++ b/gulp/nodemon.js
@@ -15,7 +15,8 @@ Gulp.task('nodemon', function () {
         ignore: [
             'client/**/*',
             'gulp/**/*',
-            'public/**/*'
+            'public/**/*',
+            'node_modules/**/*'
         ],
         nodeArgs: nodeArgs
     })


### PR DESCRIPTION
I received a nodemon error stating I was watching 26,000+ files, which might cause heavy CPU use. Ignoring node_modules in nodemon.js fixed the error.