### PR TITLE
update cookie config for client-side access

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -22,7 +22,15 @@ const manifest = {
     },
     connections: [{
         port: Config.get('/port/web'),
-        labels: ['web']
+        labels: ['web'],
+        state: {
+            isHttpOnly: false,
+            isSecure: {
+                $filter: 'env',
+                production: true,
+                $default: false
+            }
+        }
     }],
     registrations: [
         {


### PR DESCRIPTION
Resolves #100 

So in hapi v15.x (https://github.com/hapijs/hapi/issues/3323) the `HttpOnly` cookie flag is on by default. Since we need access cookies client-side (for `crumb` csrf) we disabled `HttpOnly`.