### PR TITLE
Updated hapi url

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A website and user system starter.
 
 ## Technology
 
-Server side, Aqua is built with the [hapi](https://hapijs.com/) framework.
+Server side, Aqua is built with the [hapi](http://hapijs.com/) framework.
 We're using [MongoDB](http://www.mongodb.org/) as a data store.
 
 The front-end is built with [React](https://github.com/facebook/react). We use


### PR DESCRIPTION
Since [https://hapijs.com](https://hapijs.com) goes the way of the 404 I have replaced the url with [http://hapijs.com](http://hapijs.com)

I have raised an issue mentioning the need for using HTTPS with hapijs.com [here](https://github.com/hapijs/hapijs.com/issues/434)
