### PR TITLE
Remove ensureAdminGroup('root') in pre handler

### DIFF
--- a/server/api/statuses.js
+++ b/server/api/statuses.js
@@ -29,10 +29,7 @@ internals.applyRoutes = function (server, next) {
                     limit: Joi.number().default(20),
                     page: Joi.number().default(1)
                 }
-            },
-            pre: [
-                AuthPlugin.preware.ensureAdminGroup('root')
-            ]
+            }
         },
         handler: function (request, reply) {
 


### PR DESCRIPTION
Fixes #112 

I only removed the pre handler highlighted in the issue but I noticed that all the routes for the /statuses endpoint have the same pre handler and cause the same failure, let me know if I should remove those too.
