### PR TITLE
Less ambiguous api success responses

### DIFF
--- a/server/api/accounts.js
+++ b/server/api/accounts.js
@@ -552,7 +552,7 @@ internals.applyRoutes = function (server, next) {
                     return reply(Boom.notFound('Document not found.'));
                 }
 
-                reply({ message: 'Success.' });
+                reply({ success: true });
             });
         }
     });

--- a/server/api/admin-groups.js
+++ b/server/api/admin-groups.js
@@ -235,7 +235,7 @@ internals.applyRoutes = function (server, next) {
                     return reply(Boom.notFound('Document not found.'));
                 }
 
-                reply({ message: 'Success.' });
+                reply({ success: true });
             });
         }
     });

--- a/server/api/admins.js
+++ b/server/api/admins.js
@@ -496,7 +496,7 @@ internals.applyRoutes = function (server, next) {
                     return reply(Boom.notFound('Document not found.'));
                 }
 
-                reply({ message: 'Success.' });
+                reply({ success: true });
             });
         }
     });

--- a/server/api/auth-attempts.js
+++ b/server/api/auth-attempts.js
@@ -106,7 +106,7 @@ internals.applyRoutes = function (server, next) {
                     return reply(Boom.notFound('Document not found.'));
                 }
 
-                reply({ message: 'Success.' });
+                reply({ success: true });
             });
         }
     });

--- a/server/api/contact.js
+++ b/server/api/contact.js
@@ -39,7 +39,7 @@ internals.applyRoutes = function (server, next) {
                     return reply(err);
                 }
 
-                reply({ message: 'Success.' });
+                reply({ success: true });
             });
         }
     });

--- a/server/api/login.js
+++ b/server/api/login.js
@@ -143,7 +143,7 @@ internals.applyRoutes = function (server, next) {
                         }
 
                         if (!user) {
-                            return reply({ message: 'Success.' }).takeover();
+                            return reply({ success: true }).takeover();
                         }
 
                         reply(user);
@@ -195,7 +195,7 @@ internals.applyRoutes = function (server, next) {
                     return reply(err);
                 }
 
-                reply({ message: 'Success.' });
+                reply({ success: true });
             });
         }
     });
@@ -273,7 +273,7 @@ internals.applyRoutes = function (server, next) {
                     return reply(err);
                 }
 
-                reply({ message: 'Success.' });
+                reply({ success: true });
             });
         }
     });

--- a/server/api/logout.js
+++ b/server/api/logout.js
@@ -40,7 +40,8 @@ internals.applyRoutes = function (server, next) {
                 }
 
                 request.cookieAuth.clear();
-                reply({ message: 'Success.' });
+
+                reply({ success: true });
             });
         }
     });

--- a/server/api/sessions.js
+++ b/server/api/sessions.js
@@ -106,7 +106,7 @@ internals.applyRoutes = function (server, next) {
                     return reply(Boom.notFound('Document not found.'));
                 }
 
-                reply({ message: 'Success.' });
+                reply({ success: true });
             });
         }
     });

--- a/server/api/statuses.js
+++ b/server/api/statuses.js
@@ -189,7 +189,7 @@ internals.applyRoutes = function (server, next) {
                     return reply(Boom.notFound('Document not found.'));
                 }
 
-                reply({ message: 'Success.' });
+                reply({ success: true });
             });
         }
     });

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -526,7 +526,7 @@ internals.applyRoutes = function (server, next) {
                     return reply(Boom.notFound('Document not found.'));
                 }
 
-                reply({ message: 'Success.' });
+                reply({ success: true });
             });
         }
     });

--- a/test/server/api/accounts.js
+++ b/test/server/api/accounts.js
@@ -1104,7 +1104,7 @@ lab.experiment('Accounts Plugin Delete', () => {
         server.inject(request, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
-            Code.expect(response.result.message).to.match(/success/i);
+            Code.expect(response.result.success).to.be.true();
 
             done();
         });

--- a/test/server/api/admin-groups.js
+++ b/test/server/api/admin-groups.js
@@ -426,7 +426,7 @@ lab.experiment('Admin Groups Plugin Delete', () => {
         server.inject(request, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
-            Code.expect(response.result.message).to.match(/success/i);
+            Code.expect(response.result.success).to.be.true();
 
             done();
         });

--- a/test/server/api/admins.js
+++ b/test/server/api/admins.js
@@ -947,7 +947,7 @@ lab.experiment('Admins Plugin Delete', () => {
         server.inject(request, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
-            Code.expect(response.result.message).to.match(/success/i);
+            Code.expect(response.result.success).to.be.true();
 
             done();
         });

--- a/test/server/api/auth-attempts.js
+++ b/test/server/api/auth-attempts.js
@@ -238,7 +238,7 @@ lab.experiment('Auth Attempt Plugin Delete', () => {
         server.inject(request, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
-            Code.expect(response.result.message).to.match(/success/i);
+            Code.expect(response.result.success).to.be.true();
 
             done();
         });

--- a/test/server/api/logout.js
+++ b/test/server/api/logout.js
@@ -156,7 +156,7 @@ lab.experiment('Logout Plugin (Delete Session)', () => {
         server.inject(request, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
-            Code.expect(response.result.message).to.match(/success/i);
+            Code.expect(response.result.success).to.be.true();
 
             done();
         });

--- a/test/server/api/sessions.js
+++ b/test/server/api/sessions.js
@@ -238,7 +238,7 @@ lab.experiment('Session Plugin Delete', () => {
         server.inject(request, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
-            Code.expect(response.result.message).to.match(/success/i);
+            Code.expect(response.result.success).to.be.true();
 
             done();
         });

--- a/test/server/api/statuses.js
+++ b/test/server/api/statuses.js
@@ -377,7 +377,7 @@ lab.experiment('Statuses Plugin Delete', () => {
         server.inject(request, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
-            Code.expect(response.result.message).to.match(/success/i);
+            Code.expect(response.result.success).to.be.true();
 
             done();
         });

--- a/test/server/api/users.js
+++ b/test/server/api/users.js
@@ -942,7 +942,7 @@ lab.experiment('Users Plugin Delete', () => {
         server.inject(request, (response) => {
 
             Code.expect(response.statusCode).to.equal(200);
-            Code.expect(response.result.message).to.match(/success/i);
+            Code.expect(response.result.success).to.be.true();
 
             done();
         });


### PR DESCRIPTION
Because the [parse validation helper](https://github.com/jedireza/aqua/blob/530b63d3fba727616f13a07796f5d16423869b6f/client/helpers/parse-validation.js#L38-L40) is naive, the client views were getting some unexpected results as seen in this screen shot:

<img width="240" alt="screen shot 2017-05-29 at 11 32 25 am" src="https://cloud.githubusercontent.com/assets/979929/26560060/68dd630c-4468-11e7-9135-62f0c6797591.png">

A simple solution to this was just not sending a response with a `message` key. Hence this PR changes all `{ message: "Success." }` responses with `{ success: true }`.