### PR TITLE
Fixing PropTypes warning by using number instead of integer

### DIFF
--- a/client/components/form/select-control.jsx
+++ b/client/components/form/select-control.jsx
@@ -21,7 +21,7 @@ const propTypes = {
     value: PropTypes.oneOfType([
         PropTypes.bool,
         PropTypes.string,
-        PropTypes.integer
+        PropTypes.number
     ])
 };
 const defaultProps = {


### PR DESCRIPTION
Warning in console: 

Warning: Invalid argument supplid to oneOfType. Expected an array of check functions, but received undefined at index 2.

If integer is desired, could use https://www.npmjs.com/package/react-extra-prop-types
